### PR TITLE
Update environment to nunpy 1.10.4

### DIFF
--- a/conda_env
+++ b/conda_env
@@ -1,159 +1,64 @@
-# packages in environment at /opt/anaconda/envs/numpy192:
-#
-_license                  1.1                      py27_0    defaults
-abstract-rendering        0.5.1                np19py27_0    defaults
-alabaster                 0.7.3                    py27_0    defaults
-anaconda                  2.3.0                np19py27_0    defaults
-argcomplete               0.8.9                    py27_0    defaults
-astropy                   1.0.4                np19py27_0    defaults
-babel                     1.3                      py27_0    defaults
-backports.ssl-match-hostname 3.4.0.2                   <pip>
-bcolz                     0.9.0                np19py27_0    defaults
-beautiful-soup            4.3.2                    py27_0    defaults
-beautifulsoup4            4.3.2                     <pip>
-binstar                   0.11.0                   py27_0    defaults
-bitarray                  0.8.1                    py27_0    defaults
-blaze                     0.8.0                     <pip>
-blaze-core                0.8.0                np19py27_0    defaults
-blz                       0.6.2                np19py27_1    defaults
-bokeh                     0.9.0                np19py27_0    defaults
-boto                      2.38.0                   py27_0    defaults
-bottleneck                1.0.0                np19py27_0    defaults
-cairo                     1.12.18                       6    defaults
-cdecimal                  2.3                      py27_0    defaults
-certifi                   14.05.14                 py27_0    defaults
-cffi                      1.1.0                    py27_0    defaults
-clyent                    0.3.4                    py27_0    defaults
-colorama                  0.3.3                    py27_0    defaults
-configobj                 5.0.6                    py27_0    defaults
-cryptography              0.9.1                    py27_0    defaults
-curl                      7.43.0                        0    <unknown>
-cycler                    0.9.0                    py27_0    defaults
-cython                    0.22.1                   py27_0    defaults
-cytoolz                   0.7.3                    py27_0    defaults
-datashape                 0.4.5                np19py27_0    defaults
-decorator                 3.4.2                    py27_0    defaults
-docutils                  0.12                     py27_0    defaults
-dynd-python               0.6.5                np19py27_0    defaults
-enum34                    1.0.4                    py27_0    defaults
-fastcache                 1.0.2                    py27_0    defaults
-flask                     0.10.1                   py27_1    defaults
-fontconfig                2.11.1                        5    defaults
-freetype                  2.5.5                         0    defaults
-funcsigs                  0.4                      py27_0    defaults
-gevent                    1.0.1                    py27_0    defaults
-gevent-websocket          0.9.3                    py27_0    defaults
-greenlet                  0.4.7                    py27_0    defaults
-grin                      1.2.1                    py27_1    defaults
-h5py                      2.5.0                np19py27_3    defaults
-hdf5                      1.8.15.1                      1    <unknown>
-idna                      2.0                      py27_0    defaults
-ipaddress                 1.0.7                    py27_0    defaults
-ipython                   3.2.0                    py27_0    defaults
-ipython-notebook          3.2.0                    py27_0    defaults
-ipython-qtconsole         3.2.0                    py27_0    defaults
-itsdangerous              0.24                     py27_0    defaults
-jdcal                     1.0                      py27_0    defaults
-jedi                      0.8.1                    py27_0    defaults
-jinja2                    2.7.3                    py27_1    defaults
-jpeg                      8d                            0    <unknown>
-jsonschema                2.4.0                    py27_0    defaults
-libdynd                   0.6.5                         0    <unknown>
-libffi                    3.0.13                        0    <unknown>
-libgfortran               1.0                           0    defaults
-libpng                    1.6.17                        0    <unknown>
-libsodium                 0.4.5                         0    <unknown>
-libtiff                   4.0.2                         1    <unknown>
-libxml2                   2.9.2                         0    <unknown>
-libxslt                   1.1.28                        0    <unknown>
-llvmlite                  0.5.0                    py27_0    defaults
-lxml                      3.4.4                    py27_0    defaults
-markupsafe                0.23                     py27_0    defaults
-matplotlib                1.5.1               np110py27_0    defaults
-mistune                   0.5.1                    py27_1    defaults
-mock                      1.0.1                    py27_0    defaults
-multipledispatch          0.4.7                    py27_0    defaults
-networkx                  1.9.1                    py27_0    defaults
-nltk                      3.0.3                np19py27_0    defaults
-nose                      1.3.7                    py27_0    defaults
-numba                     0.19.1               np19py27_0    defaults
-numexpr                   2.4.3                np19py27_0    defaults
-numpy                     1.10.0                   py27_0    defaults
-odo                       0.3.2                np19py27_0    defaults
-openblas                  0.2.14                        3    defaults
-openpyxl                  1.8.5                    py27_0    defaults
-openssl                   1.0.2d                        0    defaults
-pandas                    0.16.2               np19py27_0    defaults
-patsy                     0.3.0                np19py27_0    defaults
-pep8                      1.6.2                    py27_0    defaults
-pillow                    2.8.2                    py27_0    defaults
-pip                       7.1.2                    py27_0    defaults
-pixman                    0.32.6                        0    defaults
-ply                       3.6                      py27_0    defaults
-psutil                    2.2.1                    py27_0    defaults
-ptyprocess                0.4                      py27_0    defaults
-py                        1.4.27                   py27_0    defaults
-py2cairo                  1.10.0                   py27_2    defaults
-pyasn1                    0.1.7                    py27_0    defaults
-pycairo                   1.10.0                   py27_0    defaults
-pycosat                   0.6.1                    py27_0    defaults
-pycparser                 2.14                     py27_0    defaults
-pycrypto                  2.6.1                    py27_0    defaults
-pycurl                    7.19.5.1                 py27_2    defaults
-pyflakes                  0.9.2                    py27_0    defaults
-pygments                  2.0.2                    py27_0    defaults
-pyopenssl                 0.15.1                   py27_1    defaults
-pyparsing                 2.0.3                    py27_0    defaults
-pyqt                      4.11.4                   py27_1    defaults
-pytables                  3.2.0                np19py27_0    defaults
-pytest                    2.7.1                    py27_0    defaults
-python                    2.7.11                        0    defaults
-python-dateutil           2.4.2                    py27_0    defaults
-pytz                      2015.7                   py27_0    defaults
-pyyaml                    3.11                     py27_1    defaults
-pyzmq                     14.7.0                   py27_0    defaults
-qt                        4.8.7                         1    defaults
-readline                  6.2                           2    <unknown>
-redis                     2.6.9                         0    <unknown>
-redis-py                  2.10.3                   py27_0    defaults
-requests                  2.7.0                    py27_0    defaults
-rope                      0.9.4                    py27_1    defaults
-runipy                    0.1.3                    py27_0    defaults
-scikit-image              0.11.3               np19py27_0    defaults
-scikit-learn              0.16.1               np19py27_0    defaults
-scipy                     0.15.1               np19py27_0    defaults
-setuptools                19.1.1                   py27_0    defaults
-sip                       4.16.9                   py27_0    defaults
-six                       1.10.0                   py27_0    defaults
-snowballstemmer           1.2.0                    py27_0    defaults
-sockjs-tornado            1.0.1                    py27_0    defaults
-sphinx                    1.3.1                    py27_0    defaults
-sphinx-rtd-theme          0.1.7                     <pip>
-sphinx_rtd_theme          0.1.7                    py27_0    defaults
-spyder                    2.3.5.2                  py27_0    defaults
-spyder-app                2.3.5.2                  py27_0    defaults
-sqlalchemy                1.0.5                    py27_0    defaults
-sqlite                    3.8.4.1                       1    <unknown>
-ssl_match_hostname        3.4.0.2                  py27_0    defaults
-statsmodels               0.6.1                np19py27_0    defaults
-sunpy (/local/install)    0.7.dev6364               <pip>
-sympy                     0.7.6                    py27_0    defaults
-system                    5.8                           2    <unknown>
-tables                    3.2.0                     <pip>
-terminado                 0.5                      py27_0    defaults
-theano                    0.7.0                np19py27_0    defaults
-tk                        8.5.18                        0    <unknown>
-toolz                     0.7.2                    py27_0    defaults
-tornado                   4.2                      py27_0    defaults
-ujson                     1.33                     py27_0    defaults
-unicodecsv                0.9.4                    py27_0    defaults
-util-linux                2.21                          0    <unknown>
-wcsaxes                   0.6                      py27_0    astropy
-werkzeug                  0.10.4                   py27_0    defaults
-wheel                     0.26.0                   py27_1    defaults
-xlrd                      0.9.3                    py27_0    defaults
-xlsxwriter                0.7.3                    py27_0    defaults
-xlwt                      1.0.0                    py27_0    defaults
-yaml                      0.1.6                         0    <unknown>
-zeromq                    4.0.5                         0    <unknown>
-zlib                      1.2.8                         0    <unknown>
+# This file may be used to create an environment using:
+# $ conda create --name <env> --file <this file>
+# platform: linux-64
+astropy=1.1.1=np110py27_0
+beautiful-soup=4.3.2=py27_0
+bsddb=1.0=py27_0
+cairo=1.12.18=6
+contextlib2=0.4.0=py27_0
+cycler=0.9.0=py27_0
+cython=0.23.4=py27_0
+db=5.3.28=0
+decorator=4.0.6=py27_0
+fontconfig=2.11.1=5
+freetype=2.5.5=0
+funcsigs=0.4=py27_0
+glymur=0.8.2=py27_0
+jbig=2.1=0
+jinja2=2.8=py27_0
+jpeg=8d=0
+libgfortran=1.0=0
+libpng=1.6.17=0
+libtiff=4.0.6=1
+libxml2=2.9.2=0
+libxslt=1.1.28=0
+lxml=3.5.0=py27_0
+markupsafe=0.23=py27_0
+matplotlib=1.5.1=np110py27_0
+mkl=11.3.1=0
+mock=1.3.0=py27_0
+networkx=1.11=py27_0
+numpy=1.10.4=py27_0
+openjpeg=2.1.0=py27_0
+openssl=1.0.2f=0
+pandas=0.17.1=np110py27_0
+pbr=1.3.0=py27_0
+pillow=3.1.0=py27_0
+pip=8.0.2=py27_0
+pixman=0.32.6=0
+py=1.4.31=py27_0
+pycairo=1.10.0=py27_0
+pyparsing=2.0.3=py27_0
+pyqt=4.11.4=py27_1
+pytest=2.8.5=py27_0
+python=2.7.11=0
+python-dateutil=2.4.2=py27_0
+pytz=2015.7=py27_0
+pyyaml=3.11=py27_1
+qt=4.8.7=1
+readline=6.2=2
+requests=2.9.1=py27_0
+scikit-image=0.11.3=np110py27_0
+scipy=0.17.0=np110py27_1
+setuptools=19.6.2=py27_0
+sip=4.16.9=py27_0
+six=1.10.0=py27_0
+sqlalchemy=1.0.11=py27_0
+sqlite=3.9.2=0
+suds-jurko=0.6=py27_0
+tk=8.5.18=0
+wcsaxes=0.6=py27_0
+wheel=0.26.0=py27_1
+xz=5.0.5=0
+yaml=0.1.6=0
+zlib=1.2.8=0


### PR DESCRIPTION
This update, which does not change the figures allows us to check the travis run
without openBLAS, which for some reason is not needed in this newer version.
Also, the conda_env file is changed to a format that can be used to create
environemnts by
`$ conda create --name XXX --file conda_env`

This new file is successfully being used by the PR sunpy/sunpy#1629
