### PR TITLE
Fixes hash testing by using pytest-mpl

### DIFF
--- a/requirements/tests.txt
+++ b/requirements/tests.txt
@@ -1,2 +1,3 @@
 git+https://github.com/sunpy/sunpy.git
 pytest
+pytest-mpl

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -9,7 +9,7 @@ from pytest_mpl import plugin
 
 
 envs = {'py37-figure-devdeps': 'mpl_dev_ft_261_astropy_dev.json',
-        'py38-figure': 'mpl_332_ft_261_astropy_401post1.json'}
+        'py38-figure': 'mpl_332_ft_261_astropy_42.json'}
 
 
 def get_hashes(env):

--- a/tests/test_hashes.py
+++ b/tests/test_hashes.py
@@ -5,7 +5,7 @@ import urllib.request
 
 import pytest
 
-from sunpy.tests import hash
+from pytest_mpl import plugin
 
 
 envs = {'py37-figure-devdeps': 'mpl_dev_ft_261_astropy_dev.json',
@@ -36,7 +36,7 @@ def test_hashes(env):
     # Check each figure has a hash that matches
     for fig_path in envs[env]['fig_paths']:
         with open(fig_path, 'rb') as f:
-            fhash = hash._hash_file(f)
+            fhash = plugin._hash_file(f)
         fname = fig_path.stem
         if fname in hash_list:
             assert hash_list[fname] == fhash


### PR DESCRIPTION
After `sunpy.test.hash` was moved to pytest-mpl during the 2.1.0 release, this test wasn't updated.
This PR adds pytest-mpl as a dependency and uses `_hash_file()` to produce the hashes exactly how it was done before.